### PR TITLE
add automatic discovery of domains from ingress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# All those vendored packages
+vendor
+
+# Output binary
+certificate-expiry-monitor

--- a/README.md
+++ b/README.md
@@ -11,32 +11,31 @@ docker build . -t muxinc/certificate-expiry-monitor:latest
 Run the Docker image using the executable at `/app`:
 ```
 → docker run muxinc/certificate-expiry-monitor:latest /app --help
-Usage of /app:
+Usage of ./certificate-expiry-monitor:
   -domains string
-    	Comma-separated SNI domains to query
-  -ingressNamespaces string
-      If provided, a comma-separated list of namespaces that will be searched for ingresses with domains to automatically query
-  -ignoredDomains string
-      Comma-separated list of domains to exclude from the discovered set
+        Comma-separated SNI domains to query
   -frequency duration
-    	Frequency at which the certificate expiry times are polled (default 1m0s)
-  -insecure bool
-    	If true, then the InsecureSkipVerify option will be used with the TLS connection, and the remote certificate and hostname will be trusted without verification (default true)
+        Frequency at which the certificate expiry times are polled (default 1m0s)
+  -ignoredDomains string
+        Comma-separated list of domains to exclude from the discovered set
+  -ingressNamespaces string
+        If provided, a comma-separated list of namespaces that will be searched for ingresses with domains to automatically query
+  -insecure
+        If true, then the InsecureSkipVerify option will be used with the TLS connection, and the remote certificate and hostname will be trusted without verification (default true)
   -kubeconfig string
-    	Path to kubeconfig file if running outside the Kubernetes cluster
+        Path to kubeconfig file if running outside the Kubernetes cluster
   -labels string
-    	Label selector that identifies pods to query
+        Label selector that identifies pods to query
   -logformat string
-    	Log format (text or json) (default "text")
+        Log format (text or json) (default "text")
   -loglevel string
-    	Log-level threshold for logging messages (debug, info, warn, error, fatal, or panic) (default "error")
+        Log-level threshold for logging messages (debug, info, warn, error, fatal, or panic) (default "error")
   -metricsPort int
-    	TCP port that the Prometheus metrics listener should use (default 8888)
+        TCP port that the Prometheus metrics listener should use (default 8888)
   -namespaces string
-    	Comma-separated Kubernetes namespaces to query (default "default")
+        Comma-separated Kubernetes namespaces to query (default "default")
   -port int
-    	TCP port to connect to each pod on (default 443)
-
+        TCP port to connect to each pod on (default 443)
 ```
 
 ### Kubernetes Manifest

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Usage of ./certificate-expiry-monitor:
   -frequency duration
         Frequency at which the certificate expiry times are polled (default 1m0s)
   -ignoredDomains string
-        Comma-separated list of domains to exclude from the discovered set
+        Comma-separated list of domains to exclude from the discovered set. This can be a regex if the string is wrapped in forward-slashes like /.*\.domain\.com$/ which would exclude all domain.com subdomains.
   -ingressNamespaces string
         If provided, a comma-separated list of namespaces that will be searched for ingresses with domains to automatically query
   -insecure

--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ Run the Docker image using the executable at `/app`:
 Usage of /app:
   -domains string
     	Comma-separated SNI domains to query
+  -ingressNamespaces string
+      If provided, a comma-separated list of namespaces that will be searched for ingresses with domains to automatically query
+  -ignoredDomains string
+      Comma-separated list of domains to exclude from the discovered set
   -frequency duration
     	Frequency at which the certificate expiry times are polled (default 1m0s)
-  -insecure
+  -insecure bool
     	If true, then the InsecureSkipVerify option will be used with the TLS connection, and the remote certificate and hostname will be trusted without verification (default true)
   -kubeconfig string
     	Path to kubeconfig file if running outside the Kubernetes cluster
@@ -78,11 +82,11 @@ spec:
         name: certificate-expiry-monitor
         resources:
           limits:
-            cpu: 200m
-            memory: 200Mi
+            cpu: 20m
+            memory: 50Mi
           requests:
-            cpu: 200m
-            memory: 200Mi
+            cpu: 20m
+            memory: 50Mi
 ```
 
 ## Monitoring

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var (
 	labels             = flag.String("labels", "", "Label selector that identifies pods to query")
 	ingressNamespaces  = flag.String("ingressNamespaces", "", "If provided, a comma-separated list of namespaces that will be searched for ingresses with domains to automatically query")
 	domains            = flag.String("domains", "", "Comma-separated SNI domains to query")
-	ignoredDomains     = flag.String("ignoredDomains", "", "Comma-separated list of domains to exclude from the discovered set")
+	ignoredDomains     = flag.String("ignoredDomains", "", "Comma-separated list of domains to exclude from the discovered set. This can be a regex if the string is wrapped in forward-slashes like /.*\\.domain\\.com$/ which would exclude all domain.com subdomains.")
 	port               = flag.Int("port", 443, "TCP port to connect to each pod on")
 	loglevel           = flag.String("loglevel", "error", "Log-level threshold for logging messages (debug, info, warn, error, fatal, or panic)")
 	logFormat          = flag.String("logformat", "text", "Log format (text or json)")

--- a/main.go
+++ b/main.go
@@ -28,7 +28,9 @@ var (
 	pollingFrequency   = flag.Duration("frequency", time.Minute, "Frequency at which the certificate expiry times are polled")
 	namespaces         = flag.String("namespaces", "default", "Comma-separated Kubernetes namespaces to query")
 	labels             = flag.String("labels", "", "Label selector that identifies pods to query")
+	ingressNamespaces  = flag.String("ingressNamespaces", "", "If provided, a comma-separated list of namespaces that will be searched for ingresses with domains to automatically query")
 	domains            = flag.String("domains", "", "Comma-separated SNI domains to query")
+	ignoredDomains     = flag.String("ignoredDomains", "", "Comma-separated list of domains to exclude from the discovered set")
 	port               = flag.Int("port", 443, "TCP port to connect to each pod on")
 	loglevel           = flag.String("loglevel", "error", "Log-level threshold for logging messages (debug, info, warn, error, fatal, or panic)")
 	logFormat          = flag.String("logformat", "text", "Log format (text or json)")
@@ -60,7 +62,9 @@ func main() {
 		PollingFrequency:   *pollingFrequency,
 		Namespaces:         strings.Split(*namespaces, ","),
 		Labels:             *labels,
+		IngressNamespaces:  strings.Split(*ingressNamespaces, ","),
 		Domains:            strings.Split(*domains, ","),
+		IgnoredDomains:     strings.Split(*ignoredDomains, ","),
 		Port:               *port,
 		InsecureSkipVerify: *insecureSkipVerify,
 	}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"regexp"
 	"sync"
 	"time"
 
@@ -39,6 +40,9 @@ type CertExpiryMonitor struct {
 func containsDomain(l []string, domain string) bool {
 	for _, d := range l {
 		if d == domain {
+			return true
+		}
+		if regexp.MustCompile(d).MatchString(domain) {
 			return true
 		}
 	}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -42,8 +42,11 @@ func containsDomain(l []string, domain string) bool {
 		if d == domain {
 			return true
 		}
-		if regexp.MustCompile(d).MatchString(domain) {
-			return true
+		if len(d) > 2 && d[0] == '/' && d[len(d)-1] == '/' {
+			// Evaluate regexes provided like: /.*\.domain\.com$/
+			if regexp.MustCompile(d[1 : len(d)-1]).MatchString(domain) {
+				return true
+			}
 		}
 	}
 	return false

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -1,0 +1,44 @@
+package monitor
+
+import "testing"
+
+func Test_containsDomain(t *testing.T) {
+	tests := []struct {
+		name   string
+		l      []string
+		domain string
+		result bool
+	}{
+		{
+			name:   "simple domain",
+			l:      []string{"foo.com"},
+			domain: "foo.com",
+			result: true,
+		},
+		{
+			name:   "simple domain does not match subdomain",
+			l:      []string{"foo.com"},
+			domain: "bar.foo.com",
+			result: false,
+		},
+		{
+			name:   "regex matches subdomain",
+			l:      []string{`/\.foo\.com$/`},
+			domain: "bar.foo.com",
+			result: true,
+		},
+		{
+			name:   "evaulates mix of regexes and non-regexes",
+			l:      []string{"some.domain.com", `/\.foo\.com$/`},
+			domain: "bar.foo.com",
+			result: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsDomain(tt.l, tt.domain); got != tt.result {
+				t.Errorf("containsDomain(%v, %q) = %v; want %v", tt.l, tt.domain, got, tt.result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- pulls `Ingress` resources from K8S API and reads all hosts defined as part of the `IngressRule`
- allows explicit exclusion of domains/hosts
- updated example K8S YAML in README to reflect real-world resource usage