### PR TITLE
support monitoring of an explicit dialed target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://banner.mux.dev/?text=TLS%20Expiry%20Monitor" />
 
-Utility that exposes the expiry of TLS certificates as Prometheus metrics
+Utility that exposes the expiry of TLS certificates as Prometheus metrics.
 
 ## Building
 To build the Docker image, simply run `docker build`:
@@ -13,6 +13,10 @@ Run the Docker image using the executable at `/app`:
 ```
 → docker run muxinc/certificate-expiry-monitor:latest /app --help
 Usage of ./certificate-expiry-monitor:
+  -dial_target_addr string
+        If provided, dials this address directly rather than resolving pods
+  -dial_target_name string
+        Must be provided if dial_target_addr is set, identifies the explicitly configured target in the monitoring labels (still uses the pod label).
   -domains string
         Comma-separated SNI domains to query
   -frequency duration

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ var (
 	domains            = flag.String("domains", "", "Comma-separated SNI domains to query")
 	ignoredDomains     = flag.String("ignoredDomains", "", "Comma-separated list of domains to exclude from the discovered set. This can be a regex if the string is wrapped in forward-slashes like /.*\\.domain\\.com$/ which would exclude all domain.com subdomains.")
 	hostIP             = flag.Bool("hostIP", false, "If true, then connect to the host that the pod is running on rather than to the pod itself.")
+	dialTargetAddr     = flag.String("dial_target_addr", "", "If provided, dials this address directly rather than resolving pods")
+	dialTargetName     = flag.String("dial_target_name", "", "Must be provided if dial_target_addr is set, identifies the explicitly configured target in the monitoring labels (still uses the pod label).")
 	port               = flag.Int("port", 443, "TCP port to connect to each pod on")
 	loglevel           = flag.String("loglevel", "error", "Log-level threshold for logging messages (debug, info, warn, error, fatal, or panic)")
 	logFormat          = flag.String("logformat", "text", "Log format (text or json)")
@@ -56,6 +58,10 @@ func main() {
 		log.Fatalf("Error creating Kubernetes client, exiting: %v", err)
 	}
 
+	if len(*dialTargetAddr) > 0 && len(*dialTargetName) == 0 {
+		log.Fatalf("got a dial target address but not a name. must set -dial_target_name")
+	}
+
 	// start monitor
 	monitor := &monitor.CertExpiryMonitor{
 		Logger:             logger,
@@ -67,6 +73,8 @@ func main() {
 		Domains:            strings.Split(*domains, ","),
 		IgnoredDomains:     strings.Split(*ignoredDomains, ","),
 		HostIP:             *hostIP,
+		DialTargetAddr:     *dialTargetAddr,
+		DialTargetName:     *dialTargetName,
 		Port:               *port,
 		InsecureSkipVerify: *insecureSkipVerify,
 	}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -34,6 +34,8 @@ type CertExpiryMonitor struct {
 	Domains            []string
 	IgnoredDomains     []string
 	HostIP             bool
+	DialTargetAddr     string
+	DialTargetName     string
 	Port               int
 	InsecureSkipVerify bool
 }
@@ -92,6 +94,10 @@ func (m *CertExpiryMonitor) Run(ctx context.Context, wg *sync.WaitGroup) error {
 		}
 		if len(discoveredDomains) > 0 {
 			m.Domains = discoveredDomains
+		}
+
+		if len(m.DialTargetAddr) > 0 {
+			m.checkCertificates(&sync.WaitGroup{}, "DialTarget", m.DialTargetName, m.DialTargetAddr)
 		}
 
 		// iterate over namespaces to monitor


### PR DESCRIPTION
this enables the certificate-expiry-monitor to be configured to monitor certificates on an explicit address (or domain).